### PR TITLE
Adapted d-m-p configuration to create and statup the container properly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.couchbase.wildfly.swarm</groupId>
     <artifactId>nosql-microservices</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <packaging>war</packaging>
+    <packaging>jar</packaging>
 
     <name>nosql-microservices</name>
 
@@ -13,7 +13,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.wildfly-swarm>1.0.0.Beta6</version.wildfly-swarm>
         <docker.image>arungupta/nosql-microservices:latest</docker.image>
-        <swarm.port>8080</swarm.port>
     </properties>
 
     <dependencyManagement>
@@ -103,9 +102,15 @@
                                             <port>8080</port>
                                         </ports>
                                         <assembly>
-                                            <descriptorRef>artifact</descriptorRef>
+                                            <inline>
+                                                <files>
+                                                    <file>
+                                                        <source>${project.build.directory}/${project.artifactId}-swarm.jar</source>
+                                                    </file>
+                                                </files>
+                                            </inline>
                                         </assembly>
-                                        <cmd>java -jar maven/nosql-microservices.jar</cmd>
+                                        <cmd>java -jar /maven/${project.artifactId}-swarm.jar</cmd>
                                     </build>
                                     <run>
                                         <ports>
@@ -115,14 +120,13 @@
                                         <env>
                                             <COUCHBASE_URI>${docker.host.address}</COUCHBASE_URI>
                                         </env>
-                                        <!--                                <wait>
+                                        <wait>
                                             <http>
                                                 <url>http://${docker.host.address}:${swarm.port}</url>
-                                                 Change this to 200 when the URL above hits an endpoint 
                                                 <status>200</status>
                                             </http>
                                             <time>30000</time>
-                                        </wait>-->
+                                        </wait>
                                         <log>
                                             <color>yellow</color>
                                             <prefix>SWARM</prefix>


### PR DESCRIPTION
It now gives the same error as when running 'java -jar /target/*-swarm.jar' directly ;-) (i.e. some missing couchbase classes in the fat jar).

Some notes:
- To use a dynamic port ${swarm.port} must not be pre-populted. Hence I removed it.
- Unfortunately a <dependencySet> doesnt work with the assembly because somehow the swarm-maven-plugin doesn't include the 'fat' jar in the Maven reactor build.
- The swarm jar is really 'fat' : 95 MB. Not so micro, I guess. This causes the tar archive creation for the docker build to take some time.
